### PR TITLE
Update shared.lua

### DIFF
--- a/lua/weapons/pac_crossbow/shared.lua
+++ b/lua/weapons/pac_crossbow/shared.lua
@@ -53,6 +53,7 @@ function SWEP:PrimaryAttack()
 
     -- Auto-reload
     timer.Simple( self.Primary.Cooldown, function()
+        if not IsValid( self ) then return end
         self:Reload()
     end )
 end


### PR DESCRIPTION
fixes:
```
addons/cfc_pac_sweps/lua/weapons/pac_crossbow/shared.lua:56: attempt to call method 'Reload' (a nil value)
   1.  Reload - [C]:-1
    2.  unknown - addons/cfc_pac_sweps/lua/weapons/pac_crossbow/shared.lua:56
```